### PR TITLE
Feature/refact errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<!-- Spring Boot Validation -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+
 		<!-- Lombok -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/configuration/ControllerExceptionHandler.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/configuration/ControllerExceptionHandler.java
@@ -1,0 +1,68 @@
+package br.com.java01.rocketseat_projeto_java_1.configuration;
+
+import static java.util.stream.Collectors.joining;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions.ApiError;
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions.ApiException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+@ControllerAdvice
+@Slf4j
+public class ControllerExceptionHandler {
+    private static final String semicolon = "; ";
+
+
+    private String extractParameters(HttpServletRequest request) {
+        Map<String, String[]> paramMap = request.getParameterMap();
+        StringBuilder params = new StringBuilder();
+        paramMap.forEach((key, value) -> {
+            params.append(key).append('=').append(String.join(",", value)).append(semicolon);
+        });
+        return params.toString();
+    }
+
+    /**
+     * Handler for external API exceptions.
+     *
+     * @param e       the exception thrown during a request to external API.
+     * @param request the HttpServletRequest that resulted in the exception
+     * @return {@link ResponseEntity} with status code and description provided for
+     *         the handled
+     *         exception.
+     */
+    @ExceptionHandler(ApiException.class)
+    protected ResponseEntity<ApiError> handleApiException(ApiException e, HttpServletRequest request) {
+        String requestParams = extractParameters(request);
+        String requestUrl = request.getRequestURL().toString();
+
+        Integer statusCode = e.getStatusCode();
+        boolean expected = HttpStatus.INTERNAL_SERVER_ERROR.value() > statusCode;
+        if (expected) {
+            log.warn("[Internal Api warn] URL: {} Parameters: {} Status Code: {}",
+                    requestUrl, requestParams, statusCode, e);
+        } else {
+            log.error("[Internal Api error] URL: {} Parameters: {} Status Code: {}",
+                    requestUrl, requestParams, statusCode, e);
+        }
+
+        ApiError apiError = new ApiError(e.getCode(), e.getDescription(), statusCode);
+        return ResponseEntity.status(apiError.status()).body(apiError);
+    }
+
+
+}

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiError.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiError.java
@@ -1,0 +1,8 @@
+package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+
+import lombok.Builder;
+
+@Builder
+public record ApiError(String error, String message, Integer status) {
+
+}

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiError.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiError.java
@@ -1,4 +1,4 @@
-package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+package br.com.java01.rocketseat_projeto_java_1.exceptions;
 
 import lombok.Builder;
 

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiException.java
@@ -1,0 +1,48 @@
+package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+
+import java.io.Serial;
+import lombok.Getter;
+
+/**
+ * Exception containing relevant information for API errors.
+ */
+@Getter
+public class ApiException extends RuntimeException {
+
+    @Serial
+    private static final long serialVersionUID = 219337028L;
+
+    private final String code;
+    private final String description;
+    private final Integer statusCode;
+
+    /**
+     * Creates a new instance, with provided fields.
+     *
+     * @param code        API error code.
+     * @param description API error description.
+     * @param statusCode  API error HTTP Status code.
+     */
+    public ApiException(String code, String description, Integer statusCode) {
+        super(description);
+        this.code = code;
+        this.description = description;
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * Creates a new instance, with provided fields.
+     *
+     * @param code        API error code.
+     * @param description API error description.
+     * @param statusCode  API error HTTP Status code.
+     * @param cause       API error cause.
+     */
+    public ApiException(String code, String description, Integer statusCode, Throwable cause) {
+        super(description, cause);
+        this.code = code;
+        this.description = description;
+        this.statusCode = statusCode;
+    }
+
+}

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/ApiException.java
@@ -1,4 +1,4 @@
-package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+package br.com.java01.rocketseat_projeto_java_1.exceptions;
 
 import java.io.Serial;
 import lombok.Getter;

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/NotFoundException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/NotFoundException.java
@@ -1,4 +1,4 @@
-package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+package br.com.java01.rocketseat_projeto_java_1.exceptions;
 
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/NotFoundException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/exceptions/NotFoundException.java
@@ -1,0 +1,47 @@
+package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when a requested resource is not found.
+ * This exception extends {@link ApiException} and is used to indicate
+ * that a specific resource could not be found.
+ *
+ * <p>It provides constructors to create an exception instance with a code,
+ * description, and optionally a cause.</p>
+ *
+ * <p>Example usage:</p>
+ * <pre>
+ * {@code
+ * throw new NotFoundException("RESOURCE_NOT_FOUND", "The requested resource was not found.");
+ * }
+ * </pre>
+ *
+ * @see ApiException
+ */
+public class NotFoundException extends ApiException {
+
+    @Serial
+    private static final long serialVersionUID = 149728188L;
+
+    /**
+    *
+    * @param code        the error code representing the specific not found error
+    * @param description a description of the error
+    */
+    public NotFoundException(String code, String description) {
+        super(code, description, NOT_FOUND.value());
+    }
+
+    /**
+    *
+    * @param code        the error code representing the specific not found error
+    * @param description a description of the error
+    * @param cause       the underlying cause of the exception
+    */
+    public NotFoundException(String code, String description, Throwable cause) {
+        super(code, description, NOT_FOUND.value(), cause);
+    }
+}

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/controller/CourseController.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/controller/CourseController.java
@@ -1,7 +1,7 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.controller;
 
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CourseFilterDTO;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CreateCourseDTO;
-import br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions.CourseNotFoundException;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.model.Course;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.service.CourseService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,14 +15,15 @@ import jakarta.validation.constraints.Min;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.DeleteMapping;
 
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,49 +37,37 @@ public class CourseController {
     @Autowired
     private CourseService courseService;
 
-  @PostMapping
-  @Operation(summary = "Cadastro de cursos", description = "Essa função é responsável por cadastrar um novo curso")
-  @ApiResponses({
-      @ApiResponse(responseCode = "201", description = "Curso cadastrado com sucesso", content = @Content(
-          schema = @Schema(implementation = Course.class))
-      ),
-      @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content)
-  })
-  public ResponseEntity<Course> createCourse(@Valid @RequestBody CreateCourseDTO createCourseDTO) {
-    Course createdCourse = courseService.create(createCourseDTO);
-    return new ResponseEntity<>(createdCourse, HttpStatus.CREATED);
-  }
-
-  @GetMapping("/{id}")
-  @Operation(summary = "Obter curso", description = "Obtém um curso cadastrado, buscando pelo seu ID")
-  @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "Curso encontrado", content = @Content(
-          schema = @Schema(implementation = Course.class))
-      ),
-      @ApiResponse(responseCode = "404", description = "Curso não encontrado", content = @Content)
-  })
-  public ResponseEntity<?> getCourseById(@PathVariable @Min(1) @Valid Long id) {
-    try {
-      Course course = courseService.getById(id);
-      return ResponseEntity.ok(course);
-    } catch (CourseNotFoundException e) {
-      return ResponseEntity.notFound().build();
+    @PostMapping
+    @Operation(summary = "Cadastro de cursos", description = "Essa função é responsável por cadastrar um novo curso")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "Curso cadastrado com sucesso", content = @Content(schema = @Schema(implementation = Course.class))),
+            @ApiResponse(responseCode = "400", description = "Dados inválidos", content = @Content)
+    })
+    public ResponseEntity<Course> createCourse(@Valid @RequestBody CreateCourseDTO createCourseDTO) {
+        Course createdCourse = courseService.create(createCourseDTO);
+        return new ResponseEntity<>(createdCourse, HttpStatus.CREATED);
     }
-  }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Obter curso", description = "Obtém um curso cadastrado, buscando pelo seu ID")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "Curso encontrado", content = @Content(schema = @Schema(implementation = Course.class))),
+            @ApiResponse(responseCode = "404", description = "Curso não encontrado", content = @Content)
+    })
+    public ResponseEntity<?> getCourseById(@PathVariable @Min(1) @Valid Long id) {
+        Course course = courseService.getById(id);
+        return ResponseEntity.ok(course);
+    }
 
     @DeleteMapping("/{id}")
     @Operation(summary = "Remover curso", description = "Remove um curso cadastrado, identificado pelo seu ID")
     @ApiResponses({
-        @ApiResponse(responseCode = "204", description = "Curso removido", content = @Content),
-        @ApiResponse(responseCode = "404", description = "Curso não encontrado", content = @Content)
+            @ApiResponse(responseCode = "204", description = "Curso removido", content = @Content),
+            @ApiResponse(responseCode = "404", description = "Curso não encontrado", content = @Content)
     })
     public ResponseEntity<?> delete(@PathVariable @Min(1) @Valid Long id) {
-        try {
-            courseService.delete(id);
-            return new ResponseEntity<>("", HttpStatus.NO_CONTENT);
-        } catch (CourseNotFoundException e) {
-            return ResponseEntity.notFound().build();
-        }
+        courseService.delete(id);
+        return new ResponseEntity<>("", HttpStatus.NO_CONTENT);
     }
 
     @GetMapping
@@ -86,8 +75,8 @@ public class CourseController {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Lista de cursos obtida com sucesso", content = @Content(schema = @Schema(implementation = Course.class))),
     })
-    public ResponseEntity<?> getAll() {
-        List<Course> courses = courseService.getAll();
+    public ResponseEntity<?> getAll(@ModelAttribute CourseFilterDTO filter) {
+        List<Course> courses = courseService.getAll(filter);
         return ResponseEntity.ok(courses);
     }
 
@@ -98,11 +87,7 @@ public class CourseController {
             @ApiResponse(responseCode = "404", description = "Curso não encontrado", content = @Content)
     })
     public ResponseEntity<?> updateStatus(@PathVariable Long id) {
-        try {
-            Course updatedCourse = courseService.toggleStatus(id);
-            return ResponseEntity.ok(updatedCourse);
-        } catch (CourseNotFoundException e) {
-            return ResponseEntity.notFound().build();
-        }
+        Course updatedCourse = courseService.toggleStatus(id);
+        return ResponseEntity.ok(updatedCourse);
     }
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/dto/CourseFilterDTO.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/dto/CourseFilterDTO.java
@@ -1,0 +1,13 @@
+package br.com.java01.rocketseat_projeto_java_1.modules.courses.dto;
+
+import org.springframework.data.domain.Sort;
+import lombok.Builder;
+
+@Builder
+public record CourseFilterDTO(
+        String name,
+        String category,
+        String sortBy,
+        Sort.Direction sortOrder) {
+
+}

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/dto/CreateCourseDTO.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/dto/CreateCourseDTO.java
@@ -1,17 +1,17 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Builder;
-import lombok.Data;
 
-@Data
 @Builder
-public class CreateCourseDTO {
-    @NotEmpty
-    private String name;
+public record CreateCourseDTO(
+        @JsonProperty("name")
+        @NotEmpty(message = "O nome do curso é obrigatório")
+        String name,
+        @JsonProperty("category")
+        @NotEmpty(message = "A categoria do curso é obrigatória")
+        String category
+) {
 
-    @NotEmpty
-    private String category;
-
-    private boolean active;
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/exceptions/CourseNotFoundException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/exceptions/CourseNotFoundException.java
@@ -1,5 +1,7 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
 
+import br.com.java01.rocketseat_projeto_java_1.exceptions.NotFoundException;
+
 import java.io.Serial;
 
 /**

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/exceptions/CourseNotFoundException.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/exceptions/CourseNotFoundException.java
@@ -1,4 +1,22 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions;
 
-public class CourseNotFoundException extends RuntimeException {
+import java.io.Serial;
+
+/**
+ * Exception thrown when a course with the specified ID is not found.
+ *
+ */
+public class CourseNotFoundException extends NotFoundException {
+    @Serial
+    private static final long serialVersionUID = 321422596L;
+    private static final String CODE = "Not found";
+    private static final String DESCRIPTION = "Curso com id %s não encontrado";
+
+    /**
+     *
+     * @param courseId the ID of the course that was not found
+     */
+    public CourseNotFoundException(Long courseId) {
+        super(CODE, String.format(DESCRIPTION, courseId));
+    }
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/model/Course.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/model/Course.java
@@ -1,16 +1,16 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.model;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.GeneratedValue;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-
 import java.time.LocalDateTime;
 
 @Data
@@ -23,13 +23,20 @@ public class Course {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "name", nullable = false)
     private String name;
+
+    @Column(name = "category", nullable = false)
     private String category;
+
+    @Column(name = "active", nullable = false)
     private Boolean active;
 
+    @Column(name = "created_at")
     @CreationTimestamp
     private LocalDateTime createdAt;
 
+    @Column(name = "updated_at")
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/service/CourseService.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/service/CourseService.java
@@ -1,5 +1,6 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.service;
 
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CourseFilterDTO;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CreateCourseDTO;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.model.Course;
 
@@ -14,5 +15,5 @@ public interface CourseService {
 
   Course toggleStatus(Long id);
 
-  List<Course> getAll();
+  List<Course> getAll(CourseFilterDTO filter);
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/service/CourseServiceImpl.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/modules/courses/service/CourseServiceImpl.java
@@ -1,15 +1,19 @@
 package br.com.java01.rocketseat_projeto_java_1.modules.courses.service;
 
-import br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions.CourseNotFoundException;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
+import static br.com.java01.rocketseat_projeto_java_1.utils.PaginationUtils.sortBy;
+
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CourseFilterDTO;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.dto.CreateCourseDTO;
+import br.com.java01.rocketseat_projeto_java_1.modules.courses.exceptions.CourseNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.ExampleMatcher;
+import org.springframework.stereotype.Service;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.model.Course;
 import br.com.java01.rocketseat_projeto_java_1.modules.courses.repository.CourseRepository;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class CourseServiceImpl implements CourseService {
@@ -20,9 +24,9 @@ public class CourseServiceImpl implements CourseService {
   @Override
   public Course create(CreateCourseDTO createCourseDTO) {
     var course = Course.builder()
-        .name(createCourseDTO.getName())
-        .category(createCourseDTO.getCategory())
-        .active(createCourseDTO.isActive())
+        .name(createCourseDTO.name())
+        .category(createCourseDTO.category())
+        .active(true)
         .build();
 
     return courseRepository.save(course);
@@ -30,12 +34,10 @@ public class CourseServiceImpl implements CourseService {
 
   @Override
   public Course getById(Long id) {
-    Optional<Course> course = courseRepository.findById(id);
-    if (course.isEmpty()) {
-      throw new CourseNotFoundException();
-    }
+    Course course = courseRepository.findById(id)
+        .orElseThrow(() -> new CourseNotFoundException(id));
 
-    return course.get();
+    return course;
   }
 
   @Override
@@ -50,8 +52,20 @@ public class CourseServiceImpl implements CourseService {
     return courseRepository.save(course);
   }
 
-  public List<Course> getAll() {
-    return courseRepository.findAll();
+  public List<Course> getAll(CourseFilterDTO filter) {
+    Sort sort = sortBy(filter.sortBy(), filter.sortOrder());
+
+    Course courseExample = new Course();
+    courseExample.setName(filter.name());
+    courseExample.setCategory(filter.category());
+
+    ExampleMatcher matcher = ExampleMatcher.matchingAll()
+        .withIgnoreNullValues()
+        .withStringMatcher(ExampleMatcher.StringMatcher.CONTAINING); // busca parcial (contém)
+
+    Example<Course> example = Example.of(courseExample, matcher);
+
+    return courseRepository.findAll(example, sort);
   }
 
 }

--- a/src/main/java/br/com/java01/rocketseat_projeto_java_1/utils/PaginationUtils.java
+++ b/src/main/java/br/com/java01/rocketseat_projeto_java_1/utils/PaginationUtils.java
@@ -1,0 +1,24 @@
+package br.com.java01.rocketseat_projeto_java_1.utils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PaginationUtils {
+    private static final String SORT_BY_FIELD = "id";
+
+    public static Sort sortBy(String sortBy, Sort.Direction sortOrder) {
+        if (sortBy == null || sortBy.isEmpty()) {
+            return Sort.by(sortOrderOrDefault(sortOrder), SORT_BY_FIELD);
+        }
+
+        // Quando filtra por sortBy, inclui ordenação por id (unique) para garantir
+        // ordenação unica
+        return Sort.by(sortOrderOrDefault(sortOrder), sortBy, SORT_BY_FIELD);
+    }
+
+    private static Sort.Direction sortOrderOrDefault(Sort.Direction sortOrder) {
+        return (sortOrder != null) ? sortOrder : Sort.Direction.ASC;
+    }
+}


### PR DESCRIPTION
## **🎯 Problem / Objective**
<!--- Describe the problem this PR is trying to fix. Describe the objective of this task --->

- Usuário deve ter mensagens claras dos erros ao preencher dados errados;
- Endpoints devem cumprir os requerimentos da descrição do desafio: https://efficient-sloth-d85.notion.site/Desafio-01-62ef2545d8da445cb27781fadebba610

---

## **🛠️ Solution**
<!--- Describe how your solution works and how it solves the problem. --->

### Adição da dependência spring-boot-starter-validation

Existiam validações com o "Validad/Validated" porém como a dependencia de validar isso ao startar não estava no pom, essas validações não estavam funcionando.

### Adição do filter de tratamento de erros globais ControllerExceptionHandler

Filtro de exceptions com 3 tipos de tratamento:

- handleValidationExceptions - Erro ao não enviar fields obrigatórios no body ou enviar um valor com outro type; 
<img width="997" alt="f23f2333" src="https://github.com/user-attachments/assets/2af0b5fe-0b53-4f75-b004-be44a21a4090">

- handleMethodArgumentTypeMismatchException - Erro ao enviar no path um valor que não era o esperado;
<img width="987" alt="messageerrorwhenpathinvalid" src="https://github.com/user-attachments/assets/695766b3-cc45-4da4-a6eb-c33b56950606">

- handleApiException - Erro ao tentar buscar por um item que não existe no banco; 
<img width="972" alt="f2r23r23e23" src="https://github.com/user-attachments/assets/3a4f247b-9fae-418a-8606-427f57d1dae3">

### Padronização das mensagens de erro ao não encontrar um valor no banco

- Adição do NotFoundException com mensagem padrão
<img width="972" alt="f2r23r23e23" src="https://github.com/user-attachments/assets/0ea99460-7130-49ea-8814-a5776f82d4b7">

### Corrigido crud para seguir as regras do desafio

- `GET - /cursos` - Também deve ser possível realizar uma busca, filtrando os cursos pelo `name` e `category`
Ajustado para dar um like e buscar os campos que possuem o valor do "name" e/ou "category" enviada no filter.

<img width="976" alt="32r23r233" src="https://github.com/user-attachments/assets/d9e57f72-2067-4773-9edf-77fb3c59acd2">
<img width="977" alt="f32f322" src="https://github.com/user-attachments/assets/38df8940-f694-4699-89db-d448cb1f5699">

- `GET - /cursos` -  Adicionado também filtros de "sortOrder" e "sortBy":
<img width="958" alt="F23R32E32" src="https://github.com/user-attachments/assets/12d30796-5478-4eb1-92ee-5994a5cd4ee0">


- `POST - /cursos` - Deve ser possível criar um curso no banco de dados, enviando os campos `name` e `category` por meio do `body` da requisição.
Ajustado para só ter name e category nos campos de create, sem o active, além de incluir mensagens customizadas caso os campos obrigatórios não sejam adicionados.  Caso envie o "active", o valor deve ser ignorado:

<img width="962" alt="f23f23" src="https://github.com/user-attachments/assets/81c662bc-2603-458a-894e-b2b90e2bffe3">
<img width="978" alt="42f22332" src="https://github.com/user-attachments/assets/1014440e-82ae-46fb-aa4e-8cf523f2d479">

---

## **🎯 Screenshots/Videos**
<!--- Add here screenshots and/or videos showcasing your changes. --->

### Swagger atual:

<img width="1378" alt="32r23r23" src="https://github.com/user-attachments/assets/94904120-becf-48dd-bd69-60b9ac136e75">


---
